### PR TITLE
Code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,23 @@
 # CMSMS notifications channel for Laravel 5.3
 
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/laravel-notification-channels/cmsms.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/cmsms)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![Build Status](https://img.shields.io/travis/laravel-notification-channels/cmsms/master.svg?style=flat-square)](https://travis-ci.org/laravel-notification-channels/cmsms)
+[![StyleCI](https://styleci.io/repos/xxxx/shield)](https://styleci.io/repos/xxxx)
+[![SensioLabsInsight](https://img.shields.io/sensiolabs/i/xxxxx.svg?style=flat-square)](https://insight.sensiolabs.com/projects/xxxx)
+[![Quality Score](https://img.shields.io/scrutinizer/g/laravel-notification-channels/cmsms.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/cmsms)
+[![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/cmsms/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/cmsms/?branch=master)
+[![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/cmsms.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/cmsms)
+
 This package makes it easy to send [CMSMS messages](https://dashboard.onlinesmsgateway.com/docs) with Laravel 5.3.
 
 ## Contents
 
 - [Requirements](#requirements)
 - [Installation](#installation)
-- [Setting up your CMSMS account](#setting-up-your-CMSMS-account)
+- [Setting up your CMSMS account](#setting-up-your-cmsms-account)
 - [Usage](#usage)
+	- [Available message methods](#available-message-methods)
 - [Changelog](#changelog)
 - [Testing](#testing)
 - [Security](#security)
@@ -52,7 +62,7 @@ Add your CMSMS Product Token and default originator (name or number of sender) t
 ...
 ```
 
-Notice: The originator can contain a maximum of 11 alfanumeric characters.
+Notice: The originator can contain a maximum of 11 alphanumeric characters.
 
 ## Usage
 
@@ -72,12 +82,28 @@ class VpsServerOrdered extends Notification
 
     public function toCmsms($notifiable)
     {
-        return (new CmsmsMessage("Your {$notifiable->service} was ordered!"));
+        return CmsmsMessage::create("Your {$notifiable->service} was ordered!");
     }
 }
 ```
 
+
+In order to let your Notification know which phone numer you are targeting, add the `routeNotificationForCmsms` method to your Notifiable model.
+
 **Important note**: CMCMS requires the recipients phone number to be in international format. For instance: 0031612345678
+
+```php
+public function routeNotificationForCmsms()
+{
+    return '0031612345678';
+}
+```
+
+### Available message methods
+
+- `body('')`: Accepts a string value for the message body.
+- `originator('')`: Accepts a string value between 1 and 11 characters, used as the message sender name.
+- `reference('')`: Accepts a string value for your message reference. This information will be returned in a status report so you can match the message and it's status. Restrictions: 1 - 32 alphanumeric characters and reference will not work for demo accounts.
 
 ## Changelog
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
-        "phpunit/phpunit": "4.*"
+        "phpunit/phpunit": "4.*",
+        "orchestra/testbench": "^3.3"
     },
     "autoload": {
         "psr-4": {
@@ -36,7 +37,5 @@
     },
     "config": {
         "sort-packages": true
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }

--- a/src/CmsmsChannel.php
+++ b/src/CmsmsChannel.php
@@ -6,9 +6,7 @@ use Illuminate\Notifications\Notification;
 
 class CmsmsChannel
 {
-    /**
-     * @var \NotificationChannels\Cmsms\CmsmsClient
-     */
+    /** @var CmsmsClient */
     protected $client;
 
     /**
@@ -20,6 +18,8 @@ class CmsmsChannel
     }
 
     /**
+     * Send the given notification.
+     *
      * @param mixed $notifiable
      * @param \Illuminate\Notifications\Notification $notification
      *
@@ -27,12 +27,16 @@ class CmsmsChannel
      */
     public function send($notifiable, Notification $notification)
     {
+        if (! $recipient = $notifiable->routeNotificationFor('Cmsms')) {
+            return;
+        }
+
         $message = $notification->toCmsms($notifiable);
 
         if (is_string($message)) {
             $message = CmsmsMessage::create($message);
         }
 
-        $this->client->send($message);
+        $this->client->send($message, $recipient);
     }
 }

--- a/src/CmsmsClient.php
+++ b/src/CmsmsClient.php
@@ -2,8 +2,8 @@
 
 namespace NotificationChannels\Cmsms;
 
-use Exception;
 use GuzzleHttp\Client as GuzzleClient;
+use Illuminate\Support\Arr;
 use NotificationChannels\Cmsms\Exceptions\CouldNotSendNotification;
 use SimpleXMLElement;
 
@@ -11,14 +11,10 @@ class CmsmsClient
 {
     const GATEWAY_URL = 'https://sgw01.cm.nl/gateway.ashx';
 
-    /**
-     * @var GuzzleClient
-     */
+    /** @var GuzzleClient */
     protected $client;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $productToken;
 
     /**
@@ -33,18 +29,17 @@ class CmsmsClient
 
     /**
      * @param CmsmsMessage $message
+     * @param string $recipient
      * @throws CouldNotSendNotification
      */
-    public function send(CmsmsMessage $message)
+    public function send(CmsmsMessage $message, $recipient)
     {
-        if (empty($message->originator)) {
+        if (is_null(Arr::get($message->toXmlArray(), 'FROM'))) {
             $message->setOriginator(config('services.cmsms.originator'));
         }
 
-        $messageXml = $this->buildMessageXml($message);
-
         $response = $this->client->request('POST', static::GATEWAY_URL, [
-            'body' => $messageXml,
+            'body' => $this->buildMessageXml($message, $recipient),
             'headers' => [
                 'Content-Type' => 'application/xml',
             ],
@@ -60,19 +55,21 @@ class CmsmsClient
 
     /**
      * @param CmsmsMessage $message
+     * @param string $recipient
      * @return string
      */
-    protected function buildMessageXml(CmsmsMessage $message)
+    protected function buildMessageXml(CmsmsMessage $message, $recipient)
     {
         $xml = new SimpleXMLElement('<MESSAGES/>');
 
-        $authentication = $xml->addChild('AUTHENTICATION');
-        $authentication->addChild('PRODUCTTOKEN', $this->productToken);
+        $xml->addChild('AUTHENTICATION')
+            ->addChild('PRODUCTTOKEN', $this->productToken);
 
         $msg = $xml->addChild('MSG');
         foreach ($message->toXmlArray() as $name => $value) {
             $msg->addChild($name, $value);
         }
+        $msg->addChild('TO', $recipient);
 
         return $xml->asXML();
     }

--- a/src/CmsmsClient.php
+++ b/src/CmsmsClient.php
@@ -35,7 +35,7 @@ class CmsmsClient
     public function send(CmsmsMessage $message, $recipient)
     {
         if (is_null(Arr::get($message->toXmlArray(), 'FROM'))) {
-            $message->setOriginator(config('services.cmsms.originator'));
+            $message->originator(config('services.cmsms.originator'));
         }
 
         $response = $this->client->request('POST', static::GATEWAY_URL, [

--- a/src/CmsmsMessage.php
+++ b/src/CmsmsMessage.php
@@ -13,9 +13,6 @@ class CmsmsMessage
     protected $originator;
 
     /** @var string */
-    protected $recipient;
-
-    /** @var string */
     protected $reference;
 
     /**
@@ -88,7 +85,6 @@ class CmsmsMessage
         return array_filter([
             'BODY' => $this->body,
             'FROM' => $this->originator,
-            'TO' => $this->recipient,
             'REFERENCE' => $this->reference,
         ]);
     }

--- a/src/CmsmsMessage.php
+++ b/src/CmsmsMessage.php
@@ -6,41 +6,31 @@ use NotificationChannels\Cmsms\Exceptions\InvalidMessage;
 
 class CmsmsMessage
 {
-    /**
-     * @var string
-     */
-    public $body;
+    /** @var string  */
+    protected $body;
 
-    /**
-     * @var string
-     */
-    public $originator;
+    /** @var string */
+    protected $originator;
 
-    /**
-     * @var string
-     */
-    public $recipient;
+    /** @var string */
+    protected $recipient;
 
-    /**
-     * @var string
-     */
-    public $reference;
+    /** @var string */
+    protected $reference;
 
     /**
      * @param string $body
      */
     public function __construct($body = '')
     {
-        if (!empty($body)) {
-            $this->setBody($body);
-        }
+        $this->body($body);
     }
 
     /**
      * @param string $body
      * @return $this
      */
-    public function setBody($body)
+    public function body($body)
     {
         $this->body = trim($body);
 
@@ -50,9 +40,14 @@ class CmsmsMessage
     /**
      * @param string|int $originator
      * @return $this
+     * @throws InvalidMessage
      */
-    public function setOriginator($originator)
+    public function originator($originator)
     {
+        if (empty($originator) || strlen($originator) > 11) {
+            throw InvalidMessage::invalidOriginator($originator);
+        }
+
         $this->originator = (string) $originator;
 
         return $this;
@@ -62,7 +57,7 @@ class CmsmsMessage
      * @param string|int $recipient
      * @return $this
      */
-    public function setRecipient($recipient)
+    public function recipient($recipient)
     {
         $this->recipient = (string) $recipient;
 
@@ -74,7 +69,7 @@ class CmsmsMessage
      * @return $this
      * @throws InvalidMessage
      */
-    public function setReference($reference)
+    public function reference($reference)
     {
         if (empty($reference) || strlen($reference) > 32 || !ctype_alnum($reference)) {
             throw InvalidMessage::invalidReference($reference);

--- a/src/CmsmsMessage.php
+++ b/src/CmsmsMessage.php
@@ -51,17 +51,6 @@ class CmsmsMessage
     }
 
     /**
-     * @param string|int $recipient
-     * @return $this
-     */
-    public function recipient($recipient)
-    {
-        $this->recipient = (string) $recipient;
-
-        return $this;
-    }
-
-    /**
      * @param string $reference
      * @return $this
      * @throws InvalidMessage

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -10,7 +10,7 @@ class CouldNotSendNotification extends Exception
      * @param string $error
      * @return static
      */
-    public static function serviceRespondedWithAnError(string $error)
+    public static function serviceRespondedWithAnError($error)
     {
         return new static("CMSMS service responded with an error: {$error}'");
     }

--- a/src/Exceptions/InvalidMessage.php
+++ b/src/Exceptions/InvalidMessage.php
@@ -14,4 +14,13 @@ class InvalidMessage extends Exception
     {
         return new static("The reference on the CMSMS message may only contain 1 - 32 alphanumeric characters. Was given '{$reference}'");
     }
+
+    /**
+     * @param string $originator
+     * @return static
+     */
+    public static function invalidOriginator($originator)
+    {
+        return new static("The originator on the CMSMS message may only contain 1 - 11 characters. Was given '{$originator}'");
+    }
 }

--- a/tests/CmsmsChannelTest.php
+++ b/tests/CmsmsChannelTest.php
@@ -57,6 +57,6 @@ class TestNotification extends Notification
 {
     public function toCmsms($notifiable)
     {
-        return (new CmsmsMessage('Message content'))->setOriginator('APPNAME')->setRecipient('0031612345678');
+        return (new CmsmsMessage('Message content'))->originator('APPNAME');
     }
 }

--- a/tests/CmsmsClientTest.php
+++ b/tests/CmsmsClientTest.php
@@ -8,15 +8,18 @@ use Mockery;
 use NotificationChannels\Cmsms\CmsmsClient;
 use NotificationChannels\Cmsms\CmsmsMessage;
 use NotificationChannels\Cmsms\Exceptions\CouldNotSendNotification;
+use Orchestra\Testbench\TestCase;
 use PHPUnit_Framework_TestCase;
 
-class CmsmsClientTest extends PHPUnit_Framework_TestCase
+class CmsmsClientTest extends TestCase
 {
     public function setUp()
     {
+        parent::setUp();
+        $this->app['config']['services.cmsms.originator'] = 'My App';
         $this->guzzle = Mockery::mock(new Client());
         $this->client = Mockery::mock(new CmsmsClient($this->guzzle, '00000FFF-0000-F0F0-F0f0-FFFFFFFFFFFF'));
-        $this->message = (new CmsmsMessage('Message content'))->setOriginator('APPNAME')->setRecipient('0031612345678');
+        $this->message = (new CmsmsMessage('Message content'))->originator('APPNAME')->recipient('0031612345678');
     }
 
     public function tearDown()
@@ -38,9 +41,9 @@ class CmsmsClientTest extends PHPUnit_Framework_TestCase
         $this->guzzle
             ->shouldReceive('request')
             ->once()
-            ->andReturn(new Response(200, [], 'error'));
+            ->andReturn(new Response(200, [], ''));
 
-        $this->client->send($this->message);
+        $this->client->send($this->message, '00301234');
     }
 
     /** @test */
@@ -53,6 +56,6 @@ class CmsmsClientTest extends PHPUnit_Framework_TestCase
             ->once()
             ->andReturn(new Response(200, [], 'error'));
 
-        $this->client->send($this->message);
+        $this->client->send($this->message, '00301234');
     }
 }

--- a/tests/CmsmsClientTest.php
+++ b/tests/CmsmsClientTest.php
@@ -19,7 +19,7 @@ class CmsmsClientTest extends TestCase
         $this->app['config']['services.cmsms.originator'] = 'My App';
         $this->guzzle = Mockery::mock(new Client());
         $this->client = Mockery::mock(new CmsmsClient($this->guzzle, '00000FFF-0000-F0F0-F0f0-FFFFFFFFFFFF'));
-        $this->message = (new CmsmsMessage('Message content'))->originator('APPNAME')->recipient('0031612345678');
+        $this->message = (new CmsmsMessage('Message content'))->originator('APPNAME');
     }
 
     public function tearDown()

--- a/tests/CmsmsClientTest.php
+++ b/tests/CmsmsClientTest.php
@@ -47,6 +47,22 @@ class CmsmsClientTest extends TestCase
     }
 
     /** @test */
+    public function it_sets_a_default_originator_if_none_is_set()
+    {
+        $message = Mockery::mock(new CmsmsMessage('Message body'));
+        $message->shouldReceive('originator')
+                ->once()
+                ->with($this->app['config']['services.cmsms.originator']);
+
+        $this->guzzle
+            ->shouldReceive('request')
+            ->once()
+            ->andReturn(new Response(200, [], ''));
+
+        $this->client->send($message, '00301234');
+    }
+
+    /** @test */
     public function it_throws_exception_on_error_response()
     {
         $this->setExpectedException(CouldNotSendNotification::class);

--- a/tests/CmsmsMessageTest.php
+++ b/tests/CmsmsMessageTest.php
@@ -66,14 +66,6 @@ class CmsmsMessageTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function it_can_set_recipient_from_string()
-    {
-        $message = (new CmsmsMessage)->recipient('0031612345678');
-
-        $this->assertEquals('0031612345678', Arr::get($message->toXmlArray(), 'TO'));
-    }
-
-    /** @test */
     public function it_can_set_reference()
     {
         $message = (new CmsmsMessage)->reference('REFERENCE123');

--- a/tests/CmsmsMessageTest.php
+++ b/tests/CmsmsMessageTest.php
@@ -2,6 +2,7 @@
 
 namespace NotificationChannels\Cmsms\Test;
 
+use Illuminate\Support\Arr;
 use NotificationChannels\Cmsms\CmsmsMessage;
 use NotificationChannels\Cmsms\Exceptions\InvalidMessage;
 
@@ -20,7 +21,7 @@ class CmsmsMessageTest extends \PHPUnit_Framework_TestCase
     {
         $message = new CmsmsMessage('Foo');
 
-        $this->assertEquals('Foo', $message->body);
+        $this->assertEquals('Foo', Arr::get($message->toXmlArray(), 'BODY'));
     }
 
     /** @test */
@@ -29,39 +30,55 @@ class CmsmsMessageTest extends \PHPUnit_Framework_TestCase
         $message = CmsmsMessage::create('Foo');
 
         $this->assertInstanceOf(CmsmsMessage::class, $message);
-        $this->assertEquals('Foo', $message->body);
+        $this->assertEquals('Foo', Arr::get($message->toXmlArray(), 'BODY'));
     }
 
     /** @test */
     public function it_can_set_body()
     {
-        $message = (new CmsmsMessage)->setBody('Bar');
+        $message = (new CmsmsMessage)->body('Bar');
 
-        $this->assertEquals('Bar', $message->body);
+        $this->assertEquals('Bar', Arr::get($message->toXmlArray(), 'BODY'));
     }
 
     /** @test */
     public function it_can_set_originator()
     {
-        $message = (new CmsmsMessage)->setOriginator('APPNAME');
+        $message = (new CmsmsMessage)->originator('APPNAME');
 
-        $this->assertEquals('APPNAME', $message->originator);
+        $this->assertEquals('APPNAME', Arr::get($message->toXmlArray(), 'FROM'));
+    }
+
+    /** @test */
+    public function it_cannot_set_an_empty_originator()
+    {
+        $this->setExpectedException(InvalidMessage::class);
+
+        (new CmsmsMessage)->originator('');
+    }
+
+    /** @test */
+    public function it_cannot_set_an_originator_thats_too_long()
+    {
+        $this->setExpectedException(InvalidMessage::class);
+
+        (new CmsmsMessage)->originator('0123456789ab');
     }
 
     /** @test */
     public function it_can_set_recipient_from_string()
     {
-        $message = (new CmsmsMessage)->setRecipient('0031612345678');
+        $message = (new CmsmsMessage)->recipient('0031612345678');
 
-        $this->assertEquals('0031612345678', $message->recipient);
+        $this->assertEquals('0031612345678', Arr::get($message->toXmlArray(), 'TO'));
     }
 
     /** @test */
     public function it_can_set_reference()
     {
-        $message = (new CmsmsMessage)->setReference('REFERENCE123');
+        $message = (new CmsmsMessage)->reference('REFERENCE123');
 
-        $this->assertEquals('REFERENCE123', $message->reference);
+        $this->assertEquals('REFERENCE123', Arr::get($message->toXmlArray(), 'REFERENCE'));
     }
 
     /** @test */
@@ -69,15 +86,15 @@ class CmsmsMessageTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(InvalidMessage::class);
 
-        (new CmsmsMessage)->setReference('');
+        (new CmsmsMessage)->reference('');
     }
 
     /** @test */
-    public function it_cannot_set_a_reference_thats_to_long()
+    public function it_cannot_set_a_reference_thats_too_long()
     {
         $this->setExpectedException(InvalidMessage::class);
 
-        (new CmsmsMessage)->setReference('UmSM7h8I1nySJm0A8IqcU3LDswO7ojfJn');
+        (new CmsmsMessage)->reference('UmSM7h8I1nySJm0A8IqcU3LDswO7ojfJn');
     }
 
     /** @test */
@@ -85,7 +102,7 @@ class CmsmsMessageTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(InvalidMessage::class);
 
-        (new CmsmsMessage)->setReference('@#$*A*Sjks87');
+        (new CmsmsMessage)->reference('@#$*A*Sjks87');
     }
 
     /** @test */


### PR DESCRIPTION
I added and modified a few things:

* Changed the Message method names to omit the `set`, to make it equal to the other message classes
* Used the recipient number from the `routeNotificationForCmsms` method
* Removed PHP 7 `string` typehint
* Added available message methods to README
* Validate the "originator"
* Minor code style fixes


If you have any questions or comments, let me know.