### PR TITLE
Move 'tariff' in XML to messages child

### DIFF
--- a/src/CmsmsClient.php
+++ b/src/CmsmsClient.php
@@ -58,12 +58,16 @@ class CmsmsClient
      * @param string $recipient
      * @return string
      */
-    protected function buildMessageXml(CmsmsMessage $message, $recipient)
+    public function buildMessageXml(CmsmsMessage $message, $recipient)
     {
         $xml = new SimpleXMLElement('<MESSAGES/>');
 
         $xml->addChild('AUTHENTICATION')
             ->addChild('PRODUCTTOKEN', $this->productToken);
+
+        if ($tariff = $message->getTariff()) {
+            $xml->addChild('TARIFF', $tariff);
+        }
 
         $msg = $xml->addChild('MSG');
         foreach ($message->toXmlArray() as $name => $value) {

--- a/src/CmsmsMessage.php
+++ b/src/CmsmsMessage.php
@@ -16,7 +16,7 @@ class CmsmsMessage
     protected $reference;
 
     /** @var int */
-    protected $tariff;
+    protected $tariff = 0;
 
     /** @var int */
     protected $minimumNumberOfMessageParts;
@@ -92,6 +92,14 @@ class CmsmsMessage
     }
 
     /**
+     * @return int
+     */
+    public function getTariff()
+    {
+        return $this->tariff;
+    }
+
+    /**
      * @param int $minimum
      * @param int $maximum
      * @return $this
@@ -118,7 +126,6 @@ class CmsmsMessage
             'BODY' => $this->body,
             'FROM' => $this->originator,
             'REFERENCE' => $this->reference,
-            'TARIFF' => $this->tariff,
             'MINIMUMNUMBEROFMESSAGEPARTS' => $this->minimumNumberOfMessageParts,
             'MAXIMUMNUMBEROFMESSAGEPARTS' => $this->maximumNumberOfMessageParts,
         ]);

--- a/tests/CmsmsClientTest.php
+++ b/tests/CmsmsClientTest.php
@@ -73,4 +73,17 @@ class CmsmsClientTest extends TestCase
 
         $this->client->send($this->message, '00301234');
     }
+
+    /** @test */
+    public function it_includes_tariff_in_xml()
+    {
+        $message = clone $this->message;
+        $message->tariff(20);
+
+        $messageXml = $this->client->buildMessageXml($message, '00301234');
+        $parsedXml = simplexml_load_string($messageXml);
+
+        $this->assertFalse(empty($parsedXml->TARIFF));
+        $this->assertEquals(20, (int) $parsedXml->TARIFF);
+    }
 }

--- a/tests/CmsmsMessageTest.php
+++ b/tests/CmsmsMessageTest.php
@@ -102,7 +102,7 @@ class CmsmsMessageTest extends \PHPUnit_Framework_TestCase
     {
         $message = (new CmsmsMessage)->tariff(12);
 
-        $this->assertEquals(12, Arr::get($message->toXmlArray(), 'TARIFF'));
+        $this->assertEquals(12, $message->getTariff());
     }
 
     /** @test */


### PR DESCRIPTION
CM communicated that the 'TARIFF' field should be included in the <MSG> XML object, but should actually be put under the <MESSAGES> child.