### PR TITLE
Add custom creator alias to ChannelManager

### DIFF
--- a/src/CmsmsServiceProvider.php
+++ b/src/CmsmsServiceProvider.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace NotificationChannels\Cmsms;
 
 use GuzzleHttp\Client as GuzzleClient;
+use Illuminate\Foundation\Application;
+use Illuminate\Notifications\ChannelManager;
 use Illuminate\Support\ServiceProvider;
 use NotificationChannels\Cmsms\Exceptions\InvalidConfiguration;
 
 class CmsmsServiceProvider extends ServiceProvider
 {
-    public function boot(): void
+    public function register(): void
     {
         $this->app->when(CmsmsChannel::class)
             ->needs(CmsmsClient::class)
@@ -21,5 +23,9 @@ class CmsmsServiceProvider extends ServiceProvider
 
                 return new CmsmsClient(new GuzzleClient(), $productToken);
             });
+
+        $this->app->afterResolving(ChannelManager::class, static function (ChannelManager $manager) {
+            $manager->extend('cmsms', static fn (Application $app) => $app->make(CmsmsChannel::class));
+        });
     }
 }


### PR DESCRIPTION
Hey 👋🏼

This PR extends the `ChannelManager` with the `cmsms` custom creator.
The motivation behind this is, is allowing the storage of notification preferences without the need for a translation layer.

Pseudocode:

```php
public function via($notifiable): array
{
    return $notifiable->getPreferredChannels();
}
```

The only way to make it work at the moment, is by adding a translation layer which is cumbersome. Saving `FQCN`s in the database is a bad practice and frowned upon, so we'd rather avoid that. This PR addresses that.

---- 

I have also renamed `boot` to `register`, because it is "more correct" to register Service Container bindings within the `register` method. It should not cause any breaking changes since it is `boot` > `register`. The other way around could have caused it though. (`register` methods get called first, then `boot`)

Thanks for maintaining this package 🙏