### PR TITLE
WIP: Feature/encoding detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 /vendor
 build
 composer.phar

--- a/README.md
+++ b/README.md
@@ -57,11 +57,14 @@ Add your CMSMS Product Token and default originator (name or number of sender) t
 'cmsms' => [
     'product_token' => env('CMSMS_PRODUCT_TOKEN'),
     'originator' => env('CMSMS_ORIGINATOR'),
+    'encoding_detection_type' => env('CMSMS_ENCODING_DETECTION_TYPE', 'AUTO'),
 ],
 ...
 ```
 
-Notice: The originator can contain a maximum of 11 alphanumeric characters.
+Notice:
+- The originator can contain a maximum of 11 alphanumeric characters.
+- Read about encoding detection here: https://developers.cm.com/messaging/docs/sms#auto-detect-encoding
 
 ## Usage
 

--- a/src/CmsmsClient.php
+++ b/src/CmsmsClient.php
@@ -52,7 +52,7 @@ class CmsmsClient
         $body = [
             'content' => $message->getBody(),
         ];
-        if(strtoupper($encodingDetectionType) === 'AUTO'){
+        if (strtoupper($encodingDetectionType) === 'AUTO') {
             $body['type'] = 'AUTO';
         }
 

--- a/src/CmsmsMessage.php
+++ b/src/CmsmsMessage.php
@@ -31,6 +31,11 @@ class CmsmsMessage
         return $this;
     }
 
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+
     public function originator(string|int $originator): self
     {
         if (empty($originator) || strlen($originator) > 11) {
@@ -40,6 +45,11 @@ class CmsmsMessage
         $this->originator = (string) $originator;
 
         return $this;
+    }
+
+    public function getOriginator(): string
+    {
+        return $this->originator;
     }
 
     public function reference(string $reference): self

--- a/tests/CmsmsClientTest.php
+++ b/tests/CmsmsClientTest.php
@@ -43,7 +43,7 @@ class CmsmsClientTest extends TestCase
         $this->guzzle
             ->shouldReceive('request')
             ->once()
-            ->andReturn(new Response(200, [], ''));
+            ->andReturn(new Response(200, [], '{"details": "Created 1 message(s)", "errorCode": 0}'));
 
         $this->client->send($this->message, '00301234');
     }
@@ -62,7 +62,7 @@ class CmsmsClientTest extends TestCase
         $this->guzzle
             ->shouldReceive('request')
             ->once()
-            ->andReturn(new Response(200, [], ''));
+            ->andReturn(new Response(200, [], '{"details": "Created 1 message(s)", "errorCode": 0}'));
 
         $this->client->send($message, '00301234');
     }
@@ -75,21 +75,8 @@ class CmsmsClientTest extends TestCase
         $this->guzzle
             ->shouldReceive('request')
             ->once()
-            ->andReturn(new Response(200, [], 'error'));
+            ->andReturn(new Response(200, [], '{"details": "Some error message", "errorCode": 1}'));
 
         $this->client->send($this->message, '00301234');
-    }
-
-    /** @test */
-    public function it_includes_tariff_in_xml()
-    {
-        $message = clone $this->message;
-        $message->tariff(20);
-
-        $messageXml = $this->client->buildMessageXml($message, '00301234');
-        $parsedXml = simplexml_load_string($messageXml);
-
-        $this->assertFalse(empty($parsedXml->TARIFF));
-        $this->assertEquals(20, (int) $parsedXml->TARIFF);
     }
 }


### PR DESCRIPTION
Related issue: https://github.com/laravel-notification-channels/cmsms/issues/20

This might be a big change.

In order to support automatic encoding detection, I have moved from an XML body to a JSON body.
The basic structure/content is the same.

Here are the changes:
- No `TARIFF` object, as this is not declared in their documentation. Are tariffs still used or obsolete?
- Changed the gateway URL to https://gw.cmtelecom.com/v1.0/message
- Error handling: The response body is now always filled and we listen for the errorCode property
- Added config option `services.cmsms.encoding_detection_type` with default `AUTO`

TODO:
- Check if tariffs are still in usage. If not, we could refactor the code out.