### PR TITLE
Add Laravel 13 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,51 +1,55 @@
 name: run-tests
 
 on:
-  push:
-  pull_request:
+    push:
+    pull_request:
 
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ubuntu-latest]
-        php: [8.4, 8.3, 8.2]
-        laravel: ['10.*', '11.*', '12.*', '13.*']
-        stability: [prefer-lowest, prefer-stable]
-        include:
-          - laravel: 13.*
-            testbench: 11.*
-          - laravel: 12.*
-            testbench: 10.*
-          - laravel: 11.*
-            testbench: 9.*
-          - laravel: 10.*
-            testbench: 8.*
+    test:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: true
+            matrix:
+                os: [ubuntu-latest]
+                php: [8.4, 8.3, 8.2]
+                laravel: ["10.*", "11.*", "12.*", "13.*"]
+                stability: [prefer-lowest, prefer-stable]
+                include:
+                    - laravel: 13.*
+                      testbench: 11.*
+                    - laravel: 12.*
+                      testbench: 10.*
+                    - laravel: 11.*
+                      testbench: 9.*
+                    - laravel: 10.*
+                      testbench: 8.*
+                exclude:
+                    - laravel: 13.*
+                      php: 8.2
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-          coverage: none
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+                  coverage: none
 
-      - name: Setup problem matchers
-        run: |
-          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+            - name: Setup problem matchers
+              run: |
+                  echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+                  echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-      - name: Install dependencies
-        run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+            - name: Install dependencies
+              run: |
+                  composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+                  composer require "orchestra/testbench:${{ matrix.testbench }}" --dev --no-interaction --no-update
+                  composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
-      - name: Execute tests
-        run: vendor/bin/phpunit
+            - name: Execute tests
+              run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,10 +11,12 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [ 8.4 8.3, 8.2 ]
-        laravel: [ '10.*', '11.*', '12.*' ]
+        php: [8.4, 8.3, 8.2]
+        laravel: ['10.*', '11.*', '12.*', '13.*']
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
         "php": "^8.2",
         "ext-simplexml": "*",
         "guzzlehttp/guzzle": "^7.1",
-        "illuminate/notifications": "^10.0 || ^11.0 || ^12.0",
-        "illuminate/support": "^10.0 || ^11.0 || ^12.0"
+        "illuminate/notifications": "^10.0 || ^11.0 || ^12.0 || ^13.0",
+        "illuminate/support": "^10.0 || ^11.0 || ^12.0 || ^13.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.6",
         "mockery/mockery": "^1.5",
-        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0",
+        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0 || ^11.0",
         "phpunit/phpunit": "^10.5 || ^11.0"
     },
     "config": {

--- a/tests/CmsmsChannelTest.php
+++ b/tests/CmsmsChannelTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 
 class CmsmsChannelTest extends TestCase
 {
+    protected static $latestResponse;
+
     private TestNotification $notification;
     private TestNotifiable $notifiable;
     private Client $guzzle;

--- a/tests/CmsmsChannelTest.php
+++ b/tests/CmsmsChannelTest.php
@@ -9,10 +9,18 @@ use Mockery;
 use NotificationChannels\Cmsms\CmsmsChannel;
 use NotificationChannels\Cmsms\CmsmsClient;
 use NotificationChannels\Cmsms\CmsmsMessage;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class CmsmsChannelTest extends TestCase
 {
+    private TestNotification $notification;
+    private TestNotifiable $notifiable;
+    private Client $guzzle;
+    private CmsmsClient $client;
+    private CmsmsChannel $channel;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -30,17 +38,15 @@ class CmsmsChannelTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_be_instantiated()
     {
         $this->assertInstanceOf(CmsmsClient::class, $this->client);
         $this->assertInstanceOf(CmsmsChannel::class, $this->channel);
     }
 
-    /**
-     * @test
-     * @doesNotPerformAssertions
-     */
+    #[Test]
+    #[DoesNotPerformAssertions]
     public function it_shares_message()
     {
         $this->client->shouldReceive('send')->once();

--- a/tests/CmsmsChannelTest.php
+++ b/tests/CmsmsChannelTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class CmsmsChannelTest extends TestCase
 {
-    protected static $latestResponse;
+    public static $latestResponse;
 
     private TestNotification $notification;
     private TestNotifiable $notifiable;

--- a/tests/CmsmsClientTest.php
+++ b/tests/CmsmsClientTest.php
@@ -12,9 +12,15 @@ use NotificationChannels\Cmsms\Events\SMSSendingFailedEvent;
 use NotificationChannels\Cmsms\Events\SMSSentSuccessfullyEvent;
 use NotificationChannels\Cmsms\Exceptions\CouldNotSendNotification;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Test;
 
 class CmsmsClientTest extends TestCase
 {
+    private Client $guzzle;
+    private CmsmsClient $client;
+    private CmsmsMessage $message;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -30,17 +36,15 @@ class CmsmsClientTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_be_instantiated()
     {
         $this->assertInstanceOf(CmsmsClient::class, $this->client);
         $this->assertInstanceOf(CmsmsMessage::class, $this->message);
     }
 
-    /**
-     * @test
-     * @doesNotPerformAssertions
-     */
+    #[Test]
+    #[DoesNotPerformAssertions]
     public function it_can_send_message()
     {
         $this->guzzle
@@ -51,10 +55,8 @@ class CmsmsClientTest extends TestCase
         $this->client->send($this->message, '00301234');
     }
 
-    /**
-     * @test
-     * @doesNotPerformAssertions
-     */
+    #[Test]
+    #[DoesNotPerformAssertions]
     public function it_sets_a_default_originator_if_none_is_set()
     {
         $message = Mockery::mock(CmsmsMessage::create('Message body'));
@@ -70,7 +72,7 @@ class CmsmsClientTest extends TestCase
         $this->client->send($message, '00301234');
     }
 
-    /** @test */
+    #[Test]
     public function it_throws_exception_on_error_response()
     {
         $this->expectException(CouldNotSendNotification::class);
@@ -83,7 +85,7 @@ class CmsmsClientTest extends TestCase
         $this->client->send($this->message, '00301234');
     }
 
-    /** @test */
+    #[Test]
     public function it_includes_multipart_data()
     {
         $message = clone $this->message;
@@ -99,7 +101,7 @@ class CmsmsClientTest extends TestCase
         $this->assertEquals(6, $messageJsonObject->messages->msg[0]->maximumNumberOfMessageParts);
     }
 
-    /** @test */
+    #[Test]
     public function it_includes_reference_data()
     {
         $message = clone $this->message;
@@ -113,7 +115,7 @@ class CmsmsClientTest extends TestCase
         $this->assertEquals('ABC', $messageJsonObject->messages->msg[0]->reference);
     }
 
-    /** @test */
+    #[Test]
     public function it_includes_encoding_detection_type_data_in_body()
     {
         $message = clone $this->message;
@@ -128,7 +130,7 @@ class CmsmsClientTest extends TestCase
         $this->assertEquals('0', $messageJsonObject->messages->msg[0]->dcs);
     }
 
-    /** @test */
+    #[Test]
     public function it_includes_encoding_detection_type_data_in_message()
     {
         $message = clone $this->message;
@@ -142,7 +144,7 @@ class CmsmsClientTest extends TestCase
         $this->assertEquals('1', $messageJsonObject->messages->msg[0]->dcs);
     }
 
-    /** @test */
+    #[Test]
     public function it_dispatches_a_success_event()
     {
         Event::fake();
@@ -157,7 +159,7 @@ class CmsmsClientTest extends TestCase
         Event::assertDispatched(SMSSentSuccessfullyEvent::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_dispatches_a_failure_event()
     {
         Event::fake();

--- a/tests/CmsmsClientTest.php
+++ b/tests/CmsmsClientTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\Attributes\Test;
 
 class CmsmsClientTest extends TestCase
 {
+    protected static $latestResponse;
+
     private Client $guzzle;
     private CmsmsClient $client;
     private CmsmsMessage $message;
@@ -61,8 +63,8 @@ class CmsmsClientTest extends TestCase
     {
         $message = Mockery::mock(CmsmsMessage::create('Message body'));
         $message->shouldReceive('originator')
-                ->once()
-                ->with($this->app['config']['services.cmsms.originator']);
+            ->once()
+            ->with($this->app['config']['services.cmsms.originator']);
 
         $this->guzzle
             ->shouldReceive('request')

--- a/tests/CmsmsClientTest.php
+++ b/tests/CmsmsClientTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\Attributes\Test;
 
 class CmsmsClientTest extends TestCase
 {
-    protected static $latestResponse;
+    public static $latestResponse;
 
     private Client $guzzle;
     private CmsmsClient $client;

--- a/tests/CmsmsMessageTest.php
+++ b/tests/CmsmsMessageTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\TestCase;
 
 class CmsmsMessageTest extends TestCase
 {
+    protected static $latestResponse;
+
     #[Test]
     public function it_can_be_instantiated()
     {

--- a/tests/CmsmsMessageTest.php
+++ b/tests/CmsmsMessageTest.php
@@ -4,11 +4,12 @@ namespace NotificationChannels\Cmsms\Test;
 
 use NotificationChannels\Cmsms\CmsmsMessage;
 use NotificationChannels\Cmsms\Exceptions\InvalidMessage;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class CmsmsMessageTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_can_be_instantiated()
     {
         $message = CmsmsMessage::create();
@@ -16,7 +17,7 @@ class CmsmsMessageTest extends TestCase
         $this->assertInstanceOf(CmsmsMessage::class, $message);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_accept_body_content_when_created()
     {
         $message = CmsmsMessage::create('Foo');
@@ -24,7 +25,7 @@ class CmsmsMessageTest extends TestCase
         $this->assertEquals('Foo', $message->getBody());
     }
 
-    /** @test */
+    #[Test]
     public function it_supports_create_method()
     {
         $message = CmsmsMessage::create('Foo');
@@ -33,7 +34,7 @@ class CmsmsMessageTest extends TestCase
         $this->assertEquals('Foo', $message->getBody());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_body()
     {
         $message = CmsmsMessage::create('Bar');
@@ -41,7 +42,7 @@ class CmsmsMessageTest extends TestCase
         $this->assertEquals('Bar', $message->getBody());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_originator()
     {
         $message = CmsmsMessage::create()->originator('APPNAME');
@@ -49,7 +50,7 @@ class CmsmsMessageTest extends TestCase
         $this->assertEquals('APPNAME', $message->getOriginator());
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_set_an_empty_originator()
     {
         $this->expectException(InvalidMessage::class);
@@ -57,7 +58,7 @@ class CmsmsMessageTest extends TestCase
         CmsmsMessage::create()->originator('');
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_set_an_originator_thats_too_long()
     {
         $this->expectException(InvalidMessage::class);
@@ -65,7 +66,7 @@ class CmsmsMessageTest extends TestCase
         CmsmsMessage::create()->originator('0123456789ab');
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_reference()
     {
         $message = CmsmsMessage::create()->reference('REFERENCE123');
@@ -73,7 +74,7 @@ class CmsmsMessageTest extends TestCase
         $this->assertEquals('REFERENCE123', $message->getReference());
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_set_an_empty_reference()
     {
         $this->expectException(InvalidMessage::class);
@@ -81,7 +82,7 @@ class CmsmsMessageTest extends TestCase
         CmsmsMessage::create()->reference('');
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_set_a_reference_thats_too_long()
     {
         $this->expectException(InvalidMessage::class);
@@ -89,7 +90,7 @@ class CmsmsMessageTest extends TestCase
         CmsmsMessage::create()->reference('UmSM7h8I1nySJm0A8IqcU3LDswO7ojfJn');
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_set_a_reference_that_contains_non_alpha_numeric_values()
     {
         $this->expectException(InvalidMessage::class);
@@ -97,6 +98,7 @@ class CmsmsMessageTest extends TestCase
         CmsmsMessage::create()->reference('@#$*A*Sjks87');
     }
 
+    #[Test]
     public function it_can_set_multipart()
     {
         $message = CmsmsMessage::create()->multipart(1, 4);
@@ -105,6 +107,7 @@ class CmsmsMessageTest extends TestCase
         $this->assertEquals(4, $message->getMaximumNumberOfMessageParts());
     }
 
+    #[Test]
     public function it_cannot_set_more_than_8_parts_to_multipart()
     {
         $this->expectException(InvalidMessage::class);
@@ -112,7 +115,7 @@ class CmsmsMessageTest extends TestCase
         CmsmsMessage::create()->multipart(1, 9);
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_have_a_higher_minimum_than_maximum_for_multipart()
     {
         $this->expectException(InvalidMessage::class);

--- a/tests/CmsmsMessageTest.php
+++ b/tests/CmsmsMessageTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class CmsmsMessageTest extends TestCase
 {
-    protected static $latestResponse;
+    public static $latestResponse;
 
     #[Test]
     public function it_can_be_instantiated()


### PR DESCRIPTION
# Description
Add Laravel 13 support and modernise the test suite to fix PHPUnit deprecation warnings.

Solves #23 